### PR TITLE
Functional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fountain.ts",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A Typescript based parser for the screenplay format Fountain. Source originally from Matt Daly's fountain.js",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc -p .",
-    "test": "tsc -b test/ && mocha test/dist/test/*.js"
+    "test": "tsc -b test/ && mocha test/dist/test/*.js",
+    "playground": "tsc -b test/ && node test/dist/test/fountiants_playground.js"
   },
   "keywords": [
     "Typescript",

--- a/readme.md
+++ b/readme.md
@@ -3,11 +3,9 @@ Fountain-ts
 
 Fountain-ts is a TypeScript based parser for the screenplay format [Fountain](http://fountain.io/). Based on Matt Daly's [fountain-js](https://github.com/mattdaly/Fountain.js). 
 
-A work in progress at version 0.0.1. This branch in partiuclar is probably buggy.
-
 # Syntax Support
 
-Supports most of the Fountain syntax.
+Supports *most* of the Fountain syntax.
 
 Currently fountain-ts supports a limited range of key-value pairs for title pages - 
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ Fountain-ts
 
 Fountain-ts is a TypeScript based parser for the screenplay format [Fountain](http://fountain.io/). Based on Matt Daly's [fountain-js](https://github.com/mattdaly/Fountain.js). 
 
-A work in progress at version 0.0.1.
+A work in progress at version 0.0.1. This branch in partiuclar is probably buggy.
 
 # Syntax Support
 

--- a/src/fountain.ts
+++ b/src/fountain.ts
@@ -13,71 +13,59 @@ export interface Script {
 }
 
 export class Fountain {
-    private title: string; 
-    private tokens: Token[];
-    private title_page: string[];
-    private html: string[];
-
-    constructor() {
-        this.title_page = [];
-        this.html = [];
-    }
+    public tokens: Token[];
 
     public parse(script: string, getTokens?: boolean): Script {
-        this.tokens = new Scanner().tokenize(script);
-
-        let token: Token,
-            i = this.tokens.length;
-
-        while (i--) {
-            token = this.tokens[i];
-            token.text = new InlineLexer().reconstruct(token.text);
-
-            switch (token.type) {
-                case 'title': this.title_page.push('<h1>' + token.text + '</h1>'); this.title = token.text.replace('<br />', ' ').replace(/<(?:.|\n)*?>/g, ''); break;
-                case 'credit': this.title_page.push('<p class=\"credit\">' + token.text + '</p>'); break;
-                case 'author': this.title_page.push('<p class=\"authors\">' + token.text + '</p>'); break;
-                case 'authors': this.title_page.push('<p class=\"authors\">' + token.text + '</p>'); break;
-                case 'source': this.title_page.push('<p class=\"source\">' + token.text + '</p>'); break;
-                case 'notes': this.title_page.push('<p class=\"notes\">' + token.text + '</p>'); break;
-                case 'draft_date': this.title_page.push('<p class=\"draft-date\">' + token.text + '</p>'); break;
-                case 'date': this.title_page.push('<p class=\"date\">' + token.text + '</p>'); break;
-                case 'contact': this.title_page.push('<p class=\"contact\">' + token.text + '</p>'); break;
-                case 'copyright': this.title_page.push('<p class=\"copyright\">' + token.text + '</p>'); break;
-
-                case 'scene_heading': this.html.push('<h3' + (token.scene_number ? ' id=\"' + token.scene_number + '\">' : '>') + token.text + '</h3>'); break;
-                case 'transition': this.html.push('<h2>' + token.text + '</h2>'); break;
-
-                case 'dual_dialogue_begin': this.html.push('<div class=\"dual-dialogue\">'); break;
-                case 'dialogue_begin': this.html.push('<div class=\"dialogue' + (token.dual ? ' ' + token.dual : '') + '\">'); break;
-                case 'character': this.html.push('<h4>' + token.text + '</h4>'); break;
-                case 'parenthetical': this.html.push('<p class=\"parenthetical\">' + token.text + '</p>'); break;
-                case 'dialogue': this.html.push('<p>' + token.text + '</p>'); break;
-                case 'dialogue_end': this.html.push('</div>'); break;
-                case 'dual_dialogue_end': this.html.push('</div>'); break;
-
-                case 'section': this.html.push('<p class=\"section\" data-depth=\"' + token.depth + '\">' + token.text + '</p>'); break;
-                case 'synopsis': this.html.push('<p class=\"synopsis\">' + token.text + '</p>'); break;
-
-                case 'note': this.html.push('<!-- ' + token.text + '-->'); break;
-                case 'boneyard_begin': this.html.push('<!-- '); break;
-                case 'boneyard_end': this.html.push(' -->'); break;
-
-                case 'action': this.html.push('<p>' + token.text + '</p>'); break;
-                case 'centered': this.html.push('<p class=\"centered\">' + token.text + '</p>'); break;
-                
-                case 'page_break': this.html.push('<hr />'); break;
-                case 'line_break': this.html.push('<br />'); break;
-            }
-        }
+        this.tokens = new Scanner().tokenize(script).reverse();
 
         return { 
-            title: this.title, 
+            title: this.tokens.find(token => token.type == 'title').text.replace('<br />', ' ').replace(/<(?:.|\n)*?>/g, ''), 
             html: { 
-                title_page: this.title_page.join(''), 
-                script: this.html.join('') 
+                title_page: this.tokens.filter(token => token.is_title).map(token => this.to_html(token)).join(''), 
+                script: this.tokens.filter(token => !token.is_title).map(token => this.to_html(token)).join('') 
             }, 
-            tokens: getTokens ? this.tokens.reverse() : undefined
+            tokens: getTokens ? this.tokens : undefined
+        }
+    }
+
+    public to_html(token: Token): string {
+        token.text = new InlineLexer().reconstruct(token.text);
+
+        switch (token.type) {
+            case 'title': return '<h1>' + token.text + '</h1>';
+            case 'credit': return '<p class=\"credit\">' + token.text + '</p>';
+            case 'author': return '<p class=\"authors\">' + token.text + '</p>';
+            case 'authors': return '<p class=\"authors\">' + token.text + '</p>';
+            case 'source': return '<p class=\"source\">' + token.text + '</p>';
+            case 'notes': return '<p class=\"notes\">' + token.text + '</p>';
+            case 'draft_date': return '<p class=\"draft-date\">' + token.text + '</p>';
+            case 'date': return '<p class=\"date\">' + token.text + '</p>';
+            case 'contact': return '<p class=\"contact\">' + token.text + '</p>';
+            case 'copyright': return '<p class=\"copyright\">' + token.text + '</p>';
+
+            case 'scene_heading': return '<h3' + (token.scene_number ? ' id=\"' + token.scene_number + '\">' : '>') + token.text + '</h3>';
+            case 'transition': return '<h2>' + token.text + '</h2>';
+
+            case 'dual_dialogue_begin': return '<div class=\"dual-dialogue\">';
+            case 'dialogue_begin': return '<div class=\"dialogue' + (token.dual ? ' ' + token.dual : '') + '\">';
+            case 'character': return '<h4>' + token.text + '</h4>';
+            case 'parenthetical': return '<p class=\"parenthetical\">' + token.text + '</p>';
+            case 'dialogue': return '<p>' + token.text + '</p>';
+            case 'dialogue_end': return '</div>';
+            case 'dual_dialogue_end': return '</div>';
+
+            case 'section': return '<p class=\"section\" data-depth=\"' + token.depth + '\">' + token.text + '</p>';
+            case 'synopsis': return '<p class=\"synopsis\">' + token.text + '</p>';
+
+            case 'note': return '<!-- ' + token.text + '-->';
+            case 'boneyard_begin': return '<!-- ';
+            case 'boneyard_end': return ' -->';
+
+            case 'action': return '<p>' + token.text + '</p>';
+            case 'centered': return '<p class=\"centered\">' + token.text + '</p>';
+            
+            case 'page_break': return '<hr />';
+            case 'line_break': return '<br />';
         }
     }
 }

--- a/src/fountain.ts
+++ b/src/fountain.ts
@@ -5,7 +5,7 @@ import { InlineLexer } from './lexer';
 
 export interface Script {
     title: string,
-    html: { 
+    html: {
         title_page: string,
         script: string
     },
@@ -13,25 +13,26 @@ export interface Script {
 }
 
 export class Fountain {
-    public tokens: Token[];
+    private tokens: Token[];
     private scanner: Scanner;
     private inlineLex: InlineLexer;
 
-    constructor () {
+    constructor() {
         this.scanner = new Scanner;
         this.inlineLex = new InlineLexer;
     }
 
     public parse(script: string, getTokens?: boolean): Script {
-        this.tokens = this.scanner.tokenize(script).reverse();
-        let title = this.tokens.find(token => token.type == 'title');
+        this.tokens = this.scanner.tokenize(script);
+        let title = this.tokens.find(token => token.type === 'title');
 
-        return { 
-            title: title ? this.inlineLex.reconstruct(title.text).replace('<br />', ' ').replace(/<(?:.|\n)*?>/g, '') : undefined,
-            html: { 
-                title_page: this.tokens.filter(token => token.is_title).map(token => this.to_html(token)).join(''), 
-                script: this.tokens.filter(token => !token.is_title).map(token => this.to_html(token)).join('') 
-            }, 
+        return {
+            title: title ? this.inlineLex.reconstruct(title.text)
+                    .replace('<br />', ' ').replace(/<(?:.|\n)*?>/g, '') : undefined,
+            html: {
+                title_page: this.tokens.filter(token => token.is_title).map(token => this.to_html(token)).join(''),
+                script: this.tokens.filter(token => !token.is_title).map(token => this.to_html(token)).join('')
+            },
             tokens: getTokens ? this.tokens : undefined
         }
     }
@@ -65,13 +66,13 @@ export class Fountain {
             case 'section': return '<p class=\"section\" data-depth=\"' + token.depth + '\">' + token.text + '</p>';
             case 'synopsis': return '<p class=\"synopsis\">' + token.text + '</p>';
 
-            case 'note': return '<!-- ' + token.text + '-->';
+            case 'note': return '<!-- ' + token.text + ' -->';
             case 'boneyard_begin': return '<!-- ';
             case 'boneyard_end': return ' -->';
 
             case 'action': return '<p>' + token.text + '</p>';
             case 'centered': return '<p class=\"centered\">' + token.text + '</p>';
-            
+
             case 'page_break': return '<hr />';
             case 'line_break': return '<br />';
         }

--- a/src/fountain.ts
+++ b/src/fountain.ts
@@ -14,12 +14,20 @@ export interface Script {
 
 export class Fountain {
     public tokens: Token[];
+    private scanner: Scanner;
+    private inlineLex: InlineLexer;
+
+    constructor () {
+        this.scanner = new Scanner;
+        this.inlineLex = new InlineLexer;
+    }
 
     public parse(script: string, getTokens?: boolean): Script {
-        this.tokens = new Scanner().tokenize(script).reverse();
+        this.tokens = this.scanner.tokenize(script).reverse();
+        let title = this.tokens.find(token => token.type == 'title');
 
         return { 
-            title: this.tokens.find(token => token.type == 'title').text.replace('<br />', ' ').replace(/<(?:.|\n)*?>/g, ''), 
+            title: title ? this.inlineLex.reconstruct(title.text).replace('<br />', ' ').replace(/<(?:.|\n)*?>/g, '') : undefined,
             html: { 
                 title_page: this.tokens.filter(token => token.is_title).map(token => this.to_html(token)).join(''), 
                 script: this.tokens.filter(token => !token.is_title).map(token => this.to_html(token)).join('') 
@@ -29,7 +37,7 @@ export class Fountain {
     }
 
     public to_html(token: Token): string {
-        token.text = new InlineLexer().reconstruct(token.text);
+        token.text = this.inlineLex.reconstruct(token.text);
 
         switch (token.type) {
             case 'title': return '<h1>' + token.text + '</h1>';

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -12,9 +12,9 @@ export class Lexer {
 export class InlineLexer extends Lexer {
     private inline = {
         note: '<!-- $1 -->',
-    
+
         line_break: '<br />',
-    
+
         bold_italic_underline: '<span class=\"bold italic underline\">$2</span>',
         bold_underline: '<span class=\"bold underline\">$2</span>',
         italic_underline: '<span class=\"italic underline\">$2</span>',
@@ -24,27 +24,22 @@ export class InlineLexer extends Lexer {
         underline: '<span class=\"underline\">$2</span>'
     };
 
-    public reconstruct(text: string): string {
-        if (!text) {
-            return;
-        }  
+    public reconstruct(line: string): string {
+        if (!line) return;
 
-        const styles = [ 'underline', 'italic', 'bold', 'bold_italic', 'italic_underline', 'bold_underline', 'bold_italic_underline' ];
-        let i: number = styles.length;
+        let match: RegExp;
+        const styles = ['bold_italic_underline', 'bold_underline', 'italic_underline', 'bold_italic', 'bold', 'italic', 'underline'];
 
-        let style, match;
-        
-        text = text.replace(regex.note_inline, this.inline.note).replace(/\\\*/g, '[star]').replace(/\\_/g, '[underline]').replace(/\n/g, this.inline.line_break);
+        line = line.replace(regex.note_inline, this.inline.note).replace(/\\\*/g, '[star]').replace(/\\_/g, '[underline]').replace(/\n/g, this.inline.line_break);
 
-        while (i--) {
-            style = styles[i];
+        for (let style of styles) {
             match = regex[style];
 
-            if (match.test(text)) {
-                text = text.replace(match, this.inline[style]);
+            if (match.test(line)) {
+                line = line.replace(match, this.inline[style]);
             }
         }
 
-        return text.replace(/\[star\]/g, '*').replace(/\[underline\]/g, '_').trim();
+        return line.replace(/\[star\]/g, '*').replace(/\[underline\]/g, '_').trim();
     }
 }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -4,42 +4,33 @@ import { Token } from './token';
 import { Lexer } from './lexer';
 
 export class Scanner {
-    private tokens: Token[];
+    private tokens: Token[] = [];
 
-    constructor() {
-        this.tokens = [];
-    }
+    public tokenize(script: string): Token[] {
+        // reverse the array so that dual dialog can be constructed bottom up
+        const source: string[] = new Lexer().reconstruct(script).split(regex.splitter).reverse();
 
-    public tokenize(script: string) {
-        let src = new Lexer().reconstruct(script).split(regex.splitter), 
-            line: string, 
-            match: string[], 
-            parts: string[], 
-            text: string, 
-            meta: any, 
-            x: number, 
-            xlen: number, 
+        let line: string,
+            match: string[],
             dual: boolean;
 
-        let i = src.length;
-
-        while (i--) {
-            line = src[i];
-
+        for (line of source) {
             /** title page */
             if (regex.title_page.test(line)) {
                 match = line.replace(regex.title_page, '\n$1').split(regex.splitter).reverse();
 
-                for (x = 0, xlen = match.length; x < xlen; x++) {
-                    parts = match[x].replace(regex.cleaner, '').split(/\:\n*/);
-                    this.tokens.push({ type: parts[0].trim().toLowerCase().replace(' ', '_'), is_title: true, text: parts[1].trim() });
+                for (let item of match) {
+                    let pair = item.replace(regex.cleaner, '').split(/\:\n*/);
+
+                    this.tokens.push({ type: pair[0].trim().toLowerCase().replace(' ', '_'), is_title: true, text: pair[1].trim() });
                 }
                 continue;
             }
 
             /** scene headings */
             if (match = line.match(regex.scene_heading)) {
-                text = match[1] || match[2];
+                let text: string = match[1] || match[2],
+                    meta: any;
 
                 if (text.indexOf('  ') !== text.length - 2) {
                     if (meta = text.match(regex.scene_number)) {
@@ -67,20 +58,18 @@ export class Scanner {
             /** dialogue blocks - characters, parentheticals and dialogue */
             if (match = line.match(regex.dialogue)) {
                 if (match[1].indexOf('  ') !== match[1].length - 2) {
-                    // we're iterating from the bottom up, so we need to push these backwards
+                    // iterating from the bottom up, so push dialogue blocks in reverse order
                     if (match[2]) {
                         this.tokens.push({ type: 'dual_dialogue_end' });
                     }
 
                     this.tokens.push({ type: 'dialogue_end' });
 
-                    parts = match[3].split(/(\(.+\))(?:\n+)/).reverse();
+                    let parts: string[] = match[3].split(/(\(.+\))(?:\n+)/).reverse();
 
-                    for (x = 0, xlen = parts.length; x < xlen; x++) {	
-                        text = parts[x];
-
-                        if (text.length > 0) {
-                            this.tokens.push({ type: regex.parenthetical.test(text) ? 'parenthetical' : 'dialogue', text: text });
+                    for (let part of parts) {
+                        if (part.length > 0) {
+                            this.tokens.push({ type: regex.parenthetical.test(part) ? 'parenthetical' : 'dialogue', text: part });
                         }
                     }
 
@@ -92,7 +81,6 @@ export class Scanner {
                     }
 
                     dual = match[2] ? true : false;
-
                     continue;
                 }
             }
@@ -111,15 +99,15 @@ export class Scanner {
 
             /** notes */
             if (match = line.match(regex.note)) {
-                this.tokens.push({ type: 'note', text: match[1]});
+                this.tokens.push({ type: 'note', text: match[1] });
                 continue;
-            }      
+            }
 
-            /** boneyard */ 
+            /** boneyard */
             if (match = line.match(regex.boneyard)) {
                 this.tokens.push({ type: match[0][0] === '/' ? 'boneyard_begin' : 'boneyard_end' });
                 continue;
-            }      
+            }
 
             /** page breaks */
             if (regex.page_break.test(line)) {
@@ -136,6 +124,6 @@ export class Scanner {
             this.tokens.push({ type: 'action', text: line });
         }
 
-        return this.tokens;
+        return this.tokens.reverse();
     }
 }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -32,7 +32,7 @@ export class Scanner {
 
                 for (x = 0, xlen = match.length; x < xlen; x++) {
                     parts = match[x].replace(regex.cleaner, '').split(/\:\n*/);
-                    this.tokens.push({ type: parts[0].trim().toLowerCase().replace(' ', '_'), text: parts[1].trim() });
+                    this.tokens.push({ type: parts[0].trim().toLowerCase().replace(' ', '_'), is_title: true, text: parts[1].trim() });
                 }
                 continue;
             }

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,5 +1,6 @@
 export interface Token {
     type: string,
+    is_title?: boolean,
     text?: string,
     scene_number?: string,
     dual?: string,

--- a/test/fountain_test.ts
+++ b/test/fountain_test.ts
@@ -1,12 +1,12 @@
 import * as assert from 'assert';
 import { Fountain, Script } from '../src/fountain';
 
-describe('Fountain Markup Parser', function () {
-    it('should exist', function () {
+describe('Fountain Markup Parser', () => {
+    it('should exist', () => {
         assert.notEqual(Fountain, undefined);
     });
 
-    it('should return tokens when true', function () {
+    it('should return tokens when true', () => {
         let action = "It was a cold and clear morning.";
 
         let actual: Script = new Fountain().parse(action, true);
@@ -25,7 +25,7 @@ describe('Fountain Markup Parser', function () {
         assert.deepEqual(actual, expected);
     });
 
-    it('should parse a title page', function () {
+    it('should parse a title page', () => {
         let title_page = `Title:
                             _**BRICK & STEEL**_
                             _**FULL RETIRED**_
@@ -51,7 +51,7 @@ describe('Fountain Markup Parser', function () {
         assert.deepEqual(actual, expected);
     });
 
-    it('should parse a scene heading', function () {
+    it('should parse a scene heading', () => {
         let sceneHeading = "EXT. BRICK'S PATIO - DAY";
         
         let actual: Script = new Fountain().parse(sceneHeading);
@@ -67,7 +67,7 @@ describe('Fountain Markup Parser', function () {
         assert.deepEqual(actual, expected);
     });
 
-    it('should parse some transitions, forced headings and centered text', function () {
+    it('should parse some transitions, forced headings and centered text', () => {
         let text = `.OPENING TITLES
 
                     > BRICK & STEEL <
@@ -83,7 +83,7 @@ describe('Fountain Markup Parser', function () {
         assert.equal(actual, expected);
     });
 
-    it('should parse dialog', function () {
+    it('should parse dialog', () => {
         let dialog = `STEEL (O.S.)
                     Beer's ready!
 
@@ -99,7 +99,7 @@ describe('Fountain Markup Parser', function () {
         assert.equal(actual, expected);
     });
 
-    it('should parse dual dialog', function () {
+    it('should parse dual dialog', () => {
         let dualDialog = `STEEL
                         Screw retirement.
 
@@ -113,10 +113,21 @@ describe('Fountain Markup Parser', function () {
         
         assert.equal(actual, expected);
     });
+
+    it('should parse notes', () => {
+        let notes = '[[Add an additional beat here]]';
+
+        let output: Script = new Fountain().parse(notes),
+            actual: string = output.html.script;
+
+        const expected = '<!-- Add an additional beat here -->';
+
+        assert.equal(actual, expected);
+    });
 });
 
-describe('Inline markdown lexer', function () {
-    it('should parse bold italics underline', function () {
+describe('Inline markdown lexer', () => {
+    it('should parse bold italics underline', () => {
         let inlineText = '_***bold italics underline***_',
             output: Script = new Fountain().parse(inlineText);
         
@@ -126,7 +137,7 @@ describe('Inline markdown lexer', function () {
         assert.equal(actual, expected);
     });
 
-    it('should parse bold underline', function () {
+    it('should parse bold underline', () => {
         let inlineText = '_**bold underline**_',
             output: Script = new Fountain().parse(inlineText);
         
@@ -136,7 +147,7 @@ describe('Inline markdown lexer', function () {
         assert.equal(actual, expected);
     });
 
-    it('should parse italic underline', function () {
+    it('should parse italic underline', () => {
         let inlineTextAlt1 = '_*italic underline*_',
             output: Script = new Fountain().parse(inlineTextAlt1);
         
@@ -146,7 +157,7 @@ describe('Inline markdown lexer', function () {
         assert.equal(actual, expected);
     });
 
-    it('should parse an alternative italic underline', function () {
+    it('should parse an alternative italic underline', () => {
         let inlineTextAlt2 = '*_italic underline_*',
             output: Script = new Fountain().parse(inlineTextAlt2);
         
@@ -156,7 +167,7 @@ describe('Inline markdown lexer', function () {
         assert.equal(actual, expected);
     });
 
-    it('should parse bold italics', function () {
+    it('should parse bold italics', () => {
         let inlineText = '***bold italics***',
             output: Script = new Fountain().parse(inlineText);
         
@@ -166,7 +177,7 @@ describe('Inline markdown lexer', function () {
         assert.equal(actual, expected);
     });
 
-    it('should parse bold', function () {
+    it('should parse bold', () => {
         let inlineText = '**bold**',
             output: Script = new Fountain().parse(inlineText);
         
@@ -176,7 +187,7 @@ describe('Inline markdown lexer', function () {
         assert.equal(actual, expected);
     });
 
-    it('should parse italic', function () {
+    it('should parse italic', () => {
         let inlineText = '*italics*',
             output: Script = new Fountain().parse(inlineText);
         
@@ -186,7 +197,7 @@ describe('Inline markdown lexer', function () {
         assert.equal(actual, expected);
     });
 
-    it('should parse underline', function () {
+    it('should parse underline', () => {
         let inlineText = '_underline_',
             output: Script = new Fountain().parse(inlineText);
         
@@ -196,7 +207,7 @@ describe('Inline markdown lexer', function () {
         assert.equal(actual, expected);
     });
 
-    it('should parse inline markdown', function () {
+    it('should parse inline markdown', () => {
         let inlineText = '_***bold italics underline***_ _**bold underline**_ _*italic underline*_ ***bold italics*** **bold** *italics* _underline_',
             output: Script = new Fountain().parse(inlineText);
 

--- a/test/fountiants_playground.ts
+++ b/test/fountiants_playground.ts
@@ -1,5 +1,6 @@
 import { Fountain, Script } from '../src/fountain';
 import { Scanner } from '../src/scanner';
+import { InlineLexer } from '../src/lexer';
 
 let text = `Title:
             _**BRICK & STEEL**_
@@ -24,8 +25,10 @@ let text = `Title:
             (skeptical)
             Are they cold?`;
 
-//let tokens = new Scanner().tokenize(dialog);
+let line = "_**BRICK & STEEL**_\n_*FULL RETIRED*_\n\\*123\\_\n[[a note]]"
+//let tokens = new Scanner().tokenize(text);
 let output = new Fountain().parse(text);
+//let output = new InlineLexer().reconstruct(line);
 
 console.log(output);
 

--- a/test/fountiants_playground.ts
+++ b/test/fountiants_playground.ts
@@ -1,0 +1,31 @@
+import { Fountain, Script } from '../src/fountain';
+import { Scanner } from '../src/scanner';
+
+let text = `Title:
+            _**BRICK & STEEL**_
+            _**FULL RETIRED**_
+            Credit: Written by
+            Author: Stu Maschwitz
+            Source: Story by KTM
+            Draft date: 1/27/2012
+            Contact:
+            Next Level Productions
+            1588 Mission Dr.
+            Solvang, CA 93463
+
+            EXT. BRICK'S PATIO - DAY
+
+            A gorgeous day.  The sun is shining.
+
+            STEEL (O.S.)
+            Beer's ready!
+
+            BRICK
+            (skeptical)
+            Are they cold?`;
+
+//let tokens = new Scanner().tokenize(dialog);
+let output = new Fountain().parse(text);
+
+console.log(output);
+

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
+      "lib": [ "DOM", "ES2016" ],
       "target": "ES5",
-      "module": "commonjs",
       "moduleResolution": "node",
       "outDir": "dist"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "lib": [ "ES2016" ],
     "target": "ES5",
-    "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "dist"
   },


### PR DESCRIPTION
Removed the reverse `while` loops with with easier-to-understand `for, of` loops. This version also only reverses during the scanner portion, this is to preserve how dual dialogue is parsed. 

Additionally, a `to_html` method has now been added to the Fountain class that can be applied in a map function to the tokens created by scanner's tokenize. To make sure the map works best, one can filter the title page from the rest of script now with the `is_title` property.